### PR TITLE
Added mock OIDC service to docker-compose file.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,4 @@
 services:
- # app:
-  #  build:
-  #   context: .
-  # ports:
-  #   - "8082:8082"
   claim-service:
     image: wiremock/wiremock:latest
     container_name: claim-service
@@ -19,3 +14,8 @@ services:
     restart: always
     ports:
       - "8091:8080"
+  # Follow guidance here to run this service via docker: https://github.com/ministryofjustice/laa-oidc-mock-server?tab=readme-ov-file#running-the-server-via-docker
+  laa-mock-oidc-service:
+    image: laa-oidc-mock-server:latest
+    ports:
+      - "9000:9000"


### PR DESCRIPTION
## Summary

Adds the OIDC service to docker-compose, allowing you to run the mock OIDC service via docker without needing to have another repository open in IntelliJ.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
