### PR TITLE
BC-77 | Added fee type and fee code to SubmissionClaimRowMapper

### DIFF
--- a/laa-submit-a-bulk-claim-ui/build.gradle
+++ b/laa-submit-a-bulk-claim-ui/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     // Upgrade to fix vulnerabilities in spring-core
     implementation 'org.springframework:spring-core:6.2.11'
 
-    implementation 'uk.gov.justice.laa.datastewardship.payments:data-claims-api-models:0f57254'
+    implementation 'uk.gov.justice.laa.datastewardship.payments:data-claims-api-models:a92a2ea'
 
     //Common exception handling
     implementation 'uk.gov.laa.springboot:laa-spring-boot-starter-application-exception'

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/controller/ClaimDetailController.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/controller/ClaimDetailController.java
@@ -111,7 +111,9 @@ public final class ClaimDetailController {
 
   private void addFeeCalculationDetails(Model model, ClaimResponse claimResponse) {
     model.addAttribute(
-        "feeCalculationDetails", claimFeeDetailsMapper.toSubmittedFeeDetails(claimResponse));
+        "feeSubmittedDetails", claimFeeDetailsMapper.toSubmittedFeeDetails(claimResponse));
+    model.addAttribute(
+        "feeCalculationDetails", claimFeeDetailsMapper.toCalculatedFeeDetails(claimResponse));
   }
 
   private void addClaimMessages(Model model, int page, UUID submissionId, UUID claimId) {

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/dto/submission/claim/SubmissionClaimFeeCalculatedDetails.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/dto/submission/claim/SubmissionClaimFeeCalculatedDetails.java
@@ -1,0 +1,43 @@
+package uk.gov.justice.laa.bulkclaim.dto.submission.claim;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+
+/**
+ * Holds information about fee calculation in a claim.
+ *
+ * @param totalValue the total value
+ * @param adviceTime the advice time
+ * @param travelTime the travel time
+ * @param waitingTime the waiting time
+ * @param netProfitCostsAmount the net profit costs amount
+ * @param netDisbursementAmount the net disbursement amount
+ * @param netCounselCostsAmount the net counsel costs amount
+ * @param disbursementsVatAmount the disbursements VAT amount
+ * @param travelWaitingCostsAmount the travel waiting costs amount
+ * @param netWaitingCostsAmount the net waiting costs amount
+ * @param isVatApplicable the VAT applicable flag
+ * @param isLondonRate the London rate flag
+ * @param adjournedHearingFeeAmount the adjourned hearing fee amount
+ * @param costsDamagesRecoveredAmount the costs damages recovered amount
+ * @param detentionTravelWaitingCostsAmount the detention travel waiting costs amount
+ * @param jrFormFillingAmount the JR form filling amount
+ */
+@Builder
+public record SubmissionClaimFeeCalculatedDetails(
+    BigDecimal totalValue,
+    BigDecimal netProfitCostsAmount,
+    BigDecimal netDisbursementAmount,
+    BigDecimal netCounselCostsAmount,
+    BigDecimal disbursementsVatAmount,
+    BigDecimal travelWaitingCostsAmount,
+    Integer adviceTime,
+    Integer travelTime,
+    Integer waitingTime,
+    BigDecimal netWaitingCostsAmount,
+    Boolean isVatApplicable,
+    Boolean isLondonRate,
+    Integer adjournedHearingFeeAmount,
+    BigDecimal costsDamagesRecoveredAmount,
+    BigDecimal detentionTravelWaitingCostsAmount,
+    BigDecimal jrFormFillingAmount) {}

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/dto/submission/claim/SubmissionClaimFeeSubmittedDetails.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/dto/submission/claim/SubmissionClaimFeeSubmittedDetails.java
@@ -24,7 +24,7 @@ import lombok.Builder;
  * @param jrFormFillingAmount the JR form filling amount
  */
 @Builder
-public record SubmissionClaimFeeCalculationDetails(
+public record SubmissionClaimFeeSubmittedDetails(
     BigDecimal totalValue,
     BigDecimal netProfitCostsAmount,
     BigDecimal netDisbursementAmount,

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/ClaimFeeDetailsMapper.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/ClaimFeeDetailsMapper.java
@@ -1,8 +1,12 @@
 package uk.gov.justice.laa.bulkclaim.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimDetails;
-import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeCalculationDetails;
+import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeCalculatedDetails;
+import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeSubmittedDetails;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 
 /**
@@ -15,5 +19,40 @@ public interface ClaimFeeDetailsMapper {
 
   // TODO: Add new calculated fee details to the claim response object and map. This method
   //  technically maps the submitted details.
-  SubmissionClaimFeeCalculationDetails toSubmittedFeeDetails(ClaimResponse claimFields);
+  SubmissionClaimFeeSubmittedDetails toSubmittedFeeDetails(ClaimResponse claimFields);
+
+  @Mapping(source = "adviceTime", target = "adviceTime")
+  @Mapping(source = "travelTime", target = "travelTime")
+  @Mapping(source = "waitingTime", target = "waitingTime")
+  @Mapping(source = "isLondonRate", target = "isLondonRate")
+  @Mapping(source = "costsDamagesRecoveredAmount", target = "costsDamagesRecoveredAmount")
+  @Mapping(source = "feeCalculationResponse.totalAmount", target = "totalValue")
+  @Mapping(source = "feeCalculationResponse.netProfitCostsAmount", target = "netProfitCostsAmount")
+  @Mapping(
+      source = "feeCalculationResponse.requestedNetDisbursementAmount",
+      target = "netDisbursementAmount")
+  @Mapping(
+      source = "feeCalculationResponse.netCostOfCounselAmount",
+      target = "netCounselCostsAmount")
+  @Mapping(
+      source = "feeCalculationResponse.disbursementVatAmount",
+      target = "disbursementsVatAmount")
+  @Mapping(
+      source = "feeCalculationResponse.travelAndWaitingCostsAmount",
+      target = "travelWaitingCostsAmount")
+  @Mapping(
+      source = "feeCalculationResponse.netWaitingCostsAmount",
+      target = "netWaitingCostsAmount")
+  @Mapping(source = "feeCalculationResponse.vatIndicator", target = "isVatApplicable")
+  @Mapping(
+      source = "feeCalculationResponse.boltOnDetails.boltOnAdjournedHearingFee",
+      target = "adjournedHearingFeeAmount")
+  @Mapping(
+      source = "feeCalculationResponse.detentionAndWaitingCostsAmount",
+      target = "detentionTravelWaitingCostsAmount")
+  @Mapping(source = "feeCalculationResponse.jrFormFillingAmount", target = "jrFormFillingAmount")
+  @BeanMapping(
+      nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+      ignoreByDefault = true)
+  SubmissionClaimFeeCalculatedDetails toCalculatedFeeDetails(ClaimResponse claimFields);
 }

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapper.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapper.java
@@ -3,9 +3,11 @@ package uk.gov.justice.laa.bulkclaim.mapper;
 import java.math.BigDecimal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimRow;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimRowCostsDetails;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationType;
 
 /**
  * Maps between {@link ClaimResponse} and {@link SubmissionClaimRow}.
@@ -24,11 +26,21 @@ public interface SubmissionClaimRowMapper {
   @Mapping(target = "category", source = "claimFields.standardFeeCategoryCode")
   @Mapping(target = "matter", source = "claimFields.matterTypeCode")
   @Mapping(target = "concludedOrClaimedDate", source = "claimFields.caseConcludedDate")
-  // TODO: Add fee type to the OpenAPI spec.
-  @Mapping(target = "feeType", constant = "Fee type")
+  @Mapping(
+      target = "feeType",
+      source = "claimFields.feeCalculationResponse.feeType",
+      qualifiedByName = "toFeeType")
+  @Mapping(target = "feeCode", source = "claimFields.feeCalculationResponse.feeCode")
   @Mapping(target = "costsDetails", source = "claimFields")
   @Mapping(target = "totalMessages", source = "totalMessages")
   SubmissionClaimRow toSubmissionClaimRow(ClaimResponse claimFields, int totalMessages);
+
+  @Named("toFeeType")
+  default String toFeeType(final FeeCalculationType feeCalculationType) {
+    // Convert to sentence case
+    String value = feeCalculationType.getValue().replace("_", " ");
+    return value.substring(0, 1).toUpperCase() + value.substring(1).toLowerCase();
+  }
 
   @Mapping(target = "claimValue", source = "claimFields.totalValue")
   SubmissionClaimRowCostsDetails toSubmissionClaimRowCostsDetails(ClaimResponse claimFields);

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapper.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapper.java
@@ -35,6 +35,12 @@ public interface SubmissionClaimRowMapper {
   @Mapping(target = "totalMessages", source = "totalMessages")
   SubmissionClaimRow toSubmissionClaimRow(ClaimResponse claimFields, int totalMessages);
 
+  /**
+   * Maps the FeeCalculationType to a human readable string.
+   *
+   * @param feeCalculationType The FeeCalculationType to map.
+   * @return The mapped FeeCalculationType string.
+   */
   @Named("toFeeType")
   default String toFeeType(final FeeCalculationType feeCalculationType) {
     // Convert to sentence case

--- a/laa-submit-a-bulk-claim-ui/src/main/resources/templates/pages/view-claim-detail.html
+++ b/laa-submit-a-bulk-claim-ui/src/main/resources/templates/pages/view-claim-detail.html
@@ -645,73 +645,73 @@
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.netProfitCostsAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.netProfitCostsAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.netProfitCostsAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.netDisbursementAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.netDisbursementAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.netDisbursementAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.netCounselCostsAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.netCounselCostsAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.netCounselCostsAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.disbursementsVatAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.disbursementsVatAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.disbursementsVatAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.travelWaitingCostsAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.travelWaitingCostsAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.travelWaitingCostsAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.netWaitingCostsAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.netWaitingCostsAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.netWaitingCostsAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.costsDamagesRecoveredAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.costsDamagesRecoveredAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.costsDamagesRecoveredAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.costsDamagesRecoveredAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.costsDamagesRecoveredAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.costsDamagesRecoveredAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.detentionTravelWaitingCostsAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.detentionTravelWaitingCostsAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.detentionTravelWaitingCostsAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.jrFormFillingAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.jrFormFillingAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.jrFormFillingAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.adjournedHearingFeeAmount}"/>
             <td class="govuk-table__cell"
-                th:text="'£' + ${feeCalculationDetails.adjournedHearingFeeAmount}"/>
+                th:text="'£' + ${feeCalculationDetails?.adjournedHearingFeeAmount}"/>
           </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"
                 th:text="#{submission.claim.properties.totalValue}"/>
             <td class="govuk-table__cell govuk-!-font-weight-bold"
-                th:text="'£' + ${feeCalculationDetails.totalValue()}"/>
+                th:text="'£' + ${feeCalculationDetails?.totalValue()}"/>
           </tr>
           </tbody>
         </table>
@@ -723,31 +723,31 @@
             <dt class="govuk-summary-list__key"
                 th:text="#{submission.claim.properties.isVatApplicable}"/>
             <dd class="govuk-summary-list__value"
-                th:text="${feeCalculationDetails.isVatApplicable == true ? 'Yes' : 'No'}"/>
+                th:text="${feeCalculationDetails?.isVatApplicable == true ? 'Yes' : 'No'}"/>
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key"
                 th:text="#{submission.claim.properties.isLondonRate}"/>
             <dd class="govuk-summary-list__value"
-                th:text="${feeCalculationDetails.isLondonRate == true ? 'Yes' : 'No'}"/>
+                th:text="${feeCalculationDetails?.isLondonRate == true ? 'Yes' : 'No'}"/>
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key"
                 th:text="#{submission.claim.properties.adviceTime}"/>
             <dd class="govuk-summary-list__value"
-                th:text="|${feeCalculationDetails.adviceTime} #{common.minutes}|"/>
+                th:text="|${feeCalculationDetails?.adviceTime} #{common.minutes}|"/>
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key"
                 th:text="#{submission.claim.properties.travelTime}"/>
             <dd class="govuk-summary-list__value"
-                th:text="|${feeCalculationDetails.travelTime} #{common.minutes}|"/>
+                th:text="|${feeCalculationDetails?.travelTime} #{common.minutes}|"/>
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key"
                 th:text="#{submission.claim.properties.waitingTime}"/>
             <dd class="govuk-summary-list__value"
-                th:text="|${feeCalculationDetails.waitingTime} #{common.minutes}|"/>
+                th:text="|${feeCalculationDetails?.waitingTime} #{common.minutes}|"/>
           </div>
         </dl>
 

--- a/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/controller/ClaimDetailControllerTest.java
+++ b/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/controller/ClaimDetailControllerTest.java
@@ -25,7 +25,7 @@ import uk.gov.justice.laa.bulkclaim.builder.SubmissionClaimMessagesBuilder;
 import uk.gov.justice.laa.bulkclaim.client.DataClaimsRestClient;
 import uk.gov.justice.laa.bulkclaim.config.WebMvcTestConfig;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.ClaimMessagesSummary;
-import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeCalculationDetails;
+import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeSubmittedDetails;
 import uk.gov.justice.laa.bulkclaim.helper.TestObjectCreator;
 import uk.gov.justice.laa.bulkclaim.mapper.ClaimFeeDetailsMapper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
@@ -76,7 +76,7 @@ class ClaimDetailControllerTest {
       when(dataClaimsRestClient.getSubmissionClaim(submissionId, claimId))
           .thenReturn(Mono.just(claimResponse));
       when(claimFeeDetailsMapper.toSubmittedFeeDetails(claimResponse))
-          .thenReturn(SubmissionClaimFeeCalculationDetails.builder().build());
+          .thenReturn(SubmissionClaimFeeSubmittedDetails.builder().build());
 
       assertThat(
               mockMvc.perform(
@@ -131,7 +131,7 @@ class ClaimDetailControllerTest {
       when(dataClaimsRestClient.getSubmissionClaim(submissionId, claimId))
           .thenReturn(Mono.just(claimResponse));
       when(claimFeeDetailsMapper.toSubmittedFeeDetails(claimResponse))
-          .thenReturn(SubmissionClaimFeeCalculationDetails.builder().build());
+          .thenReturn(SubmissionClaimFeeSubmittedDetails.builder().build());
 
       assertThat(
               mockMvc.perform(

--- a/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/helper/TestObjectCreator.java
+++ b/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/helper/TestObjectCreator.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimDetails;
-import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeCalculationDetails;
+import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeSubmittedDetails;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 
@@ -213,9 +213,9 @@ public final class TestObjectCreator {
         .build();
   }
 
-  public static SubmissionClaimFeeCalculationDetails buildFeeCalculationDetails() {
+  public static SubmissionClaimFeeSubmittedDetails buildFeeCalculationDetails() {
 
-    return SubmissionClaimFeeCalculationDetails.builder()
+    return SubmissionClaimFeeSubmittedDetails.builder()
         .totalValue(new BigDecimal("1234.56"))
         .adviceTime(6)
         .travelTime(7)

--- a/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/mapper/ClaimFeeDetailsMapperTest.java
+++ b/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/mapper/ClaimFeeDetailsMapperTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeCalculationDetails;
+import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimFeeSubmittedDetails;
 import uk.gov.justice.laa.bulkclaim.helper.TestObjectCreator;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 
@@ -28,7 +28,7 @@ class ClaimFeeDetailsMapperTest {
     // Given
     ClaimResponse claimResponse = TestObjectCreator.buildClaimResponse();
     // When
-    SubmissionClaimFeeCalculationDetails result = mapper.toSubmittedFeeDetails(claimResponse);
+    SubmissionClaimFeeSubmittedDetails result = mapper.toSubmittedFeeDetails(claimResponse);
     // Then
     SoftAssertions.assertSoftly(
         softAssertions -> {

--- a/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapperTest.java
+++ b/laa-submit-a-bulk-claim-ui/src/test/java/uk/gov/justice/laa/bulkclaim/mapper/SubmissionClaimRowMapperTest.java
@@ -12,6 +12,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimRow;
 import uk.gov.justice.laa.bulkclaim.dto.submission.claim.SubmissionClaimRowCostsDetails;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationPatch;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationType;
 
 @DisplayName("Submission claim row mapper test")
 @ExtendWith(SpringExtension.class)
@@ -47,6 +49,11 @@ class SubmissionClaimRowMapperTest {
             // TODO: Fee type is not available on OpenAPI spec.
             // .feeType("Fee type")
             .feeCode("Fee code")
+            .feeCalculationResponse(
+                FeeCalculationPatch.builder()
+                    .feeType(FeeCalculationType.DISBURSEMENT_ONLY)
+                    .feeCode("FC123")
+                    .build())
             .build();
     // When
     SubmissionClaimRow result = mapper.toSubmissionClaimRow(claimResponse, 2);
@@ -65,8 +72,8 @@ class SubmissionClaimRowMapperTest {
           softAssertions
               .assertThat(result.concludedOrClaimedDate())
               .isEqualTo(LocalDate.of(2025, 3, 18));
-          softAssertions.assertThat(result.feeType()).isEqualTo("Fee type");
-          softAssertions.assertThat(result.feeCode()).isEqualTo("Fee code");
+          softAssertions.assertThat(result.feeType()).isEqualTo("Disbursement only");
+          softAssertions.assertThat(result.feeCode()).isEqualTo("FC123");
           softAssertions.assertThat(result.costsDetails()).isNotNull();
           softAssertions.assertThat(result.totalMessages()).isEqualTo(2);
         });


### PR DESCRIPTION
## Summary

[Link to story](https://dsdmoj.atlassian.net/browse/BC-77)

Added `FeeType` and `FeeCode` to `SubmissionClaimRowMapper`. Also bumped claims API model version to latest to include `FeeCalculationDetails` on `ClaimResponse`, ensured to map both submitted and calculated fee details.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
