### PR TITLE
Story/bc 127 from and to date on the search submission calendar are disabled for the current day

### DIFF
--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/controller/SearchController.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/controller/SearchController.java
@@ -49,8 +49,6 @@ public class SearchController {
   private final OidcAttributeUtils oidcAttributeUtils;
 
   public static final String SUBMISSION_SEARCH_FORM = "submissionsSearchForm";
-  private static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("d/M/yyyy");
   private static final int DEFAULT_PAGE = 0;
   private static final int DEFAULT_PAGE_SIZE = 10;
 
@@ -69,6 +67,9 @@ public class SearchController {
     if (!model.containsAttribute(SUBMISSION_SEARCH_FORM)) {
       model.addAttribute(SUBMISSION_SEARCH_FORM, new SubmissionsSearchForm(null, null, null));
     }
+    model.addAttribute(
+        "standardDate",
+        LocalDate.now().plusDays(1).format(DateTimeFormatter.ofPattern("M/d/yyyy")));
     sessionStatus.setComplete();
     return "pages/submissions-search";
   }
@@ -187,7 +188,7 @@ public class SearchController {
       return null;
     }
     try {
-      return LocalDate.parse(date.trim(), DATE_TIME_FORMATTER);
+      return LocalDate.parse(date.trim(), DateTimeFormatter.ofPattern("d/M/yyyy"));
     } catch (DateTimeParseException exception) {
       log.warn("Unable to parse submitted date '{}': {}", date, exception.getMessage());
       return null;

--- a/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/validation/SubmissionSearchValidator.java
+++ b/laa-submit-a-bulk-claim-ui/src/main/java/uk/gov/justice/laa/bulkclaim/validation/SubmissionSearchValidator.java
@@ -76,19 +76,12 @@ public class SubmissionSearchValidator implements Validator {
 
     LocalDate maxDate = LocalDate.now().plusDays(1);
 
-    if (dateFrom != null
-        && dateFrom.isBefore(maxDate)) {
+    if (dateFrom != null && dateFrom.isBefore(maxDate)) {
       errors.rejectValue(
           SUBMITTED_DATE_FROM, "date.range.invalid", "From date must be on or before today.");
-      errors.rejectValue(
-          SUBMITTED_DATE_TO, "date.range.invalid", "To date must be on or before today.");
     }
-    if (dateFrom != null
-        && dateTo != null
-        && dateFrom.isBefore(maxDate)
-        && dateTo.isBefore(maxDate)) {
-      errors.rejectValue(
-          SUBMITTED_DATE_FROM, "date.range.invalid", "From date must be on or before today.");
+
+    if (dateTo != null && dateTo.isBefore(maxDate)) {
       errors.rejectValue(
           SUBMITTED_DATE_TO, "date.range.invalid", "To date must be on or before today.");
     }

--- a/laa-submit-a-bulk-claim-ui/src/main/resources/templates/fragments/submission-search.html
+++ b/laa-submit-a-bulk-claim-ui/src/main/resources/templates/fragments/submission-search.html
@@ -23,10 +23,7 @@
            th:classappend="${#fields.hasErrors('submittedDateFrom')} ? 'govuk-form-group--error'">
         <div class="govuk-date-input__item">
           <div class="moj-datepicker" data-module="moj-date-picker"
-               th:attr="data-min-date=#{search.date.min},
-                         data-max-date=#{search.date.max},
-                         data-excluded-dates=#{search.date.excludedDates},
-                         data-excluded-days=#{search.date.excludedDays}">
+               th:attr="data-max-date=${#dates.format(standardDate, 'dd/M/yyyy')}">
 
             <div class="govuk-form-group">
               <label class="govuk-label" for="submittedDateFrom"
@@ -46,11 +43,7 @@
            th:classappend="${#fields.hasErrors('submittedDateTo')} ? 'govuk-form-group--error'">
         <div class="govuk-date-input__item">
           <div class="moj-datepicker" data-module="moj-date-picker"
-               th:attr="data-min-date=#{search.date.min},
-                         data-max-date=#{search.date.max},
-                         data-excluded-dates=#{search.date.excludedDates},
-                         data-excluded-days=#{search.date.excludedDays}"
-          >
+               th:attr="data-max-date=${#dates.format(standardDate, 'dd/M/yyyy')}">
             <div class="govuk-form-group">
               <label class="govuk-label" for="submittedDateTo"
                      th:text="#{search.submittedDateTo.label}">


### PR DESCRIPTION
## Summary

[BC-127](https://dsdmoj.atlassian.net/browse/BC-127)

Users should be able to select today’s date for searches.

Future dates should be disabled to prevent invalid search submissions.

Backend validation should also reject todays date, and future dates in case the user were to manually enter the date into the text boxes.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
