### PR TITLE
Removing target ref field to use `main` branch

### DIFF
--- a/.github/workflows/deploy-uat-preview.yml
+++ b/.github/workflows/deploy-uat-preview.yml
@@ -38,7 +38,6 @@ jobs:
       test_annotation: "@smoke"
       pr_number: ${{ github.event.number }}
       github_app_organisation: 'ministryofjustice'
-      target_ref: 'feature/run-e2e-in-docker'
     secrets:
       github_app_id: ${{ vars.LAA_CCMS_CAAB_SERVICE_APP_ID }}
       github_app_private_key: ${{ secrets.LAA_CCMS_CAAB_SERVICE_KEY }}


### PR DESCRIPTION
## Summary

Flag was left pointing to wrong branch for test-smoke job in deploy-uat-preview. This is removed so that jobs run on `main` instead.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
