### PR TITLE
upgrade netty to 4.2.13.Final to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)

### DIFF
--- a/laa-submit-a-bulk-claim-ui/build.gradle
+++ b/laa-submit-a-bulk-claim-ui/build.gradle
@@ -22,6 +22,8 @@ repositories {
 ext['tomcat.version'] = '11.0.21'
 // Upgrade to fix SNYK-JAVA-ORGAPACHELOGGINGLOG4J-15967727 and related vulnerabilities
 ext['log4j2.version'] = '2.25.4'
+// Upgrade to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)
+ext['netty.version'] = '4.2.13.Final'
 
 dependencyManagement {
     dependencies {


### PR DESCRIPTION

## Summary

upgrade netty to 4.2.13.Final to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)